### PR TITLE
Start listeners before all connections are setup

### DIFF
--- a/scala-loci-lang/shared/src/main/scala/loci/runtime/Runtime.scala
+++ b/scala-loci-lang/shared/src/main/scala/loci/runtime/Runtime.scala
@@ -147,13 +147,13 @@ class Runtime[P](
         remoteConnections connect (connector, peer)
     }
 
+    listeners foreach { case (listener, peer) =>
+      remoteConnections listen (listener, peer)
+    }
+
     future foreach { requiredConnectedRemotes =>
       val remotes = optionalConnectors map { case (connector, peer) =>
         remoteConnections connect (connector, peer)
-      }
-
-      listeners foreach { case (listener, peer) =>
-        remoteConnections listen (listener, peer)
       }
 
       remoteConnections.terminated notify { _ =>


### PR DESCRIPTION
Allows for circular dependencies on the network graph