### PR TITLE
Remove obsolete webrtc reliable check

### DIFF
--- a/communicator-webrtc/js/src/main/scala/loci/communicator/webrtc/WebRTCConnector.scala
+++ b/communicator-webrtc/js/src/main/scala/loci/communicator/webrtc/WebRTCConnector.scala
@@ -157,7 +157,7 @@ private class WebRTCChannelConnector(
     extends Connector[WebRTC] {
 
   protected def connect(connectionEstablished: Connected[WebRTC]) = {
-    val reliable = channel.ordered && channel.maxPacketLifeTime == 0 && channel.maxRetransmits == 0
+    val reliable = channel.ordered && channel.asInstanceOf[js.Dynamic].maxPacketLifeTime == null && channel.asInstanceOf[js.Dynamic].maxRetransmits == null
 
     if (reliable) {
       val connection = {


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/reliable it should not be used any more and messages are reliable and ordered by default.