### PR TITLE
sbt: akkaHttp & play: add TestInternal dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -108,13 +108,18 @@ val jsoniter = Seq(
 val akkaHttp = libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-http" % "10.1.15" % CompileInternal cross CrossVersion.for3Use2_13,
   "com.typesafe.akka" %% "akka-stream" % "2.5.32" % CompileInternal cross CrossVersion.for3Use2_13,
+  "com.typesafe.akka" %% "akka-http" % "10.1.15" % TestInternal cross CrossVersion.for3Use2_13,
+  "com.typesafe.akka" %% "akka-stream" % "2.5.32" % TestInternal cross CrossVersion.for3Use2_13,
   "com.typesafe.akka" %% "akka-http" % "[10.0,11.0)" % Provided cross CrossVersion.for3Use2_13,
   "com.typesafe.akka" %% "akka-stream" % "[2.4,3.0)" % Provided cross CrossVersion.for3Use2_13)
 
 val play = libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-http" % "10.1.15" % CompileInternal cross CrossVersion.for3Use2_13,
   "com.typesafe.akka" %% "akka-stream" % "2.5.32" % CompileInternal cross CrossVersion.for3Use2_13,
+  "com.typesafe.akka" %% "akka-http" % "10.1.15" % TestInternal cross CrossVersion.for3Use2_13,
+  "com.typesafe.akka" %% "akka-stream" % "2.5.32" % TestInternal cross CrossVersion.for3Use2_13,
   "com.typesafe.play" %% "play" % "2.7.9" % CompileInternal cross CrossVersion.for3Use2_13 withIsTransitive false,
+  "com.typesafe.play" %% "play" % "2.7.9" % TestInternal cross CrossVersion.for3Use2_13 withIsTransitive false,
   "com.typesafe.play" %% "play" % "[2.5,2.9)" % Provided cross CrossVersion.for3Use2_13 withIsTransitive false)
 
 val scalajsDom = libraryDependencies +=


### PR DESCRIPTION
I am trying to add some features to ScalaLoci, but my local tests and CIs kept failing for some Scala versions (2.12, 3.x) but not others (2.11, 2.13).

In the investigation I noticed that in the Test configuration different versions of Akka were used, notably "2.5.32" for akka-stream in Compile but "2.9.0-M1" in Test.

This can be seen for example with the `dependencyClasspath` task in sbt, see below.

I have never used the `CompileInternal` scope in a sbt project so I am uncertain if this PR is the right approach, but it seems adding the `TestInternal` scope resolves the problem.

```
sbt:loci> ++3.3.0
[info] Setting Scala version to 3.3.0 on 39 projects.
[info] Reapplying settings...
[info] set current project to loci (in build file:/data/git/scala-loci/)
sbt:loci> show lociCommunicatorWsAkkaJVM/dependencyClasspath
[info] compiling 2 Scala sources to /data/git/scala-loci/communication/.prelude/jvm/target/scala-3.3.0/classes ...
[info] compiling 55 Scala sources to /data/git/scala-loci/communication/jvm/target/scala-3.3.0/classes ...
[info] * Attributed(/data/git/scala-loci/communication/jvm/target/scala-3.3.0/classes)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-library_3/3.3.0/scala3-library_3-3.3.0.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-http_2.13/10.1.15/akka-http_2.13-10.1.15.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-stream_2.13/2.5.32/akka-stream_2.13-2.5.32.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/com/outr/scribe_3/3.10.7/scribe_3-3.10.7.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.10/scala-library-2.13.10.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-http-core_2.13/10.1.15/akka-http-core_2.13-10.1.15.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-actor_2.13/2.5.32/akka-actor_2.13-2.5.32.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-protobuf_2.13/2.5.32/akka-protobuf_2.13-2.5.32.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/reactivestreams/reactive-streams/1.0.2/reactive-streams-1.0.2.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/ssl-config-core_2.13/0.3.8/ssl-config-core_2.13-0.3.8.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/com/outr/perfolation_3/1.2.9/perfolation_3-1.2.9.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/sourcecode_3/0.3.0/sourcecode_3-0.3.0.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-collection-compat_3/2.9.0/scala-collection-compat_3-2.9.0.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/com/outr/moduload_3/1.1.6/moduload_3-1.1.6.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-parsing_2.13/10.1.15/akka-parsing_2.13-10.1.15.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/config/1.3.3/config-1.3.3.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-java8-compat_2.13/0.9.0/scala-java8-compat_2.13-0.9.0.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.13/1.1.2/scala-parser-combinators_2.13-1.1.2.jar)
[success] Total time: 54 s, completed 10 Sep 2023, 20:36:14
sbt:loci> show lociCommunicatorWsAkkaJVM/Test/dependencyClasspath
[info] compiling 1 Scala source to /data/git/scala-loci/communication/.prelude/jvm/target/scala-3.3.0/test-classes ...
[info] compiling 8 Scala sources to /data/git/scala-loci/communicator-ws-akka/jvm/target/scala-3.3.0/classes ...
[info] compiling 9 Scala sources to /data/git/scala-loci/communication/jvm/target/scala-3.3.0/test-classes ...
[info] * Attributed(/data/git/scala-loci/communicator-ws-akka/jvm/target/scala-3.3.0/classes)
[info] * Attributed(/data/git/scala-loci/communication/jvm/target/scala-3.3.0/classes)
[info] * Attributed(/data/git/scala-loci/communication/jvm/target/scala-3.3.0/test-classes)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-library_3/3.3.0/scala3-library_3-3.3.0.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-http_2.13/10.5.2/akka-http_2.13-10.5.2.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-stream_2.13/2.9.0-M1/akka-stream_2.13-2.9.0-M1.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scalatest/scalatest_3/3.2.16/scalatest_3-3.2.16.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/com/outr/scribe_3/3.10.7/scribe_3-3.10.7.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.11/scala-library-2.13.11.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-http-core_2.13/10.5.2/akka-http-core_2.13-10.5.2.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-actor_2.13/2.9.0-M1/akka-actor_2.13-2.9.0-M1.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-protobuf-v3_2.13/2.9.0-M1/akka-protobuf-v3_2.13-2.9.0-M1.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/reactivestreams/reactive-streams/1.0.4/reactive-streams-1.0.4.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-core_3/3.2.16/scalatest-core_3-3.2.16.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-featurespec_3/3.2.16/scalatest-featurespec_3-3.2.16.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-flatspec_3/3.2.16/scalatest-flatspec_3-3.2.16.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-freespec_3/3.2.16/scalatest-freespec_3-3.2.16.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-funsuite_3/3.2.16/scalatest-funsuite_3-3.2.16.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-funspec_3/3.2.16/scalatest-funspec_3-3.2.16.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-propspec_3/3.2.16/scalatest-propspec_3-3.2.16.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-refspec_3/3.2.16/scalatest-refspec_3-3.2.16.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-wordspec_3/3.2.16/scalatest-wordspec_3-3.2.16.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-diagrams_3/3.2.16/scalatest-diagrams_3-3.2.16.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-matchers-core_3/3.2.16/scalatest-matchers-core_3-3.2.16.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-shouldmatchers_3/3.2.16/scalatest-shouldmatchers_3-3.2.16.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-mustmatchers_3/3.2.16/scalatest-mustmatchers_3-3.2.16.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/com/outr/perfolation_3/1.2.9/perfolation_3-1.2.9.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/com/lihaoyi/sourcecode_3/0.3.0/sourcecode_3-0.3.0.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-collection-compat_3/2.9.0/scala-collection-compat_3-2.9.0.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/com/outr/moduload_3/1.1.6/moduload_3-1.1.6.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-parsing_2.13/10.5.2/akka-parsing_2.13-10.5.2.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/config/1.4.2/config-1.4.2.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-java8-compat_2.13/1.0.0/scala-java8-compat_2.13-1.0.0.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scalactic/scalactic_3/3.2.16/scalactic_3-3.2.16.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scalatest/scalatest-compatible/3.2.16/scalatest-compatible-3.2.16.jar)
[info] * Attributed(/home/locke/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_3/2.1.0/scala-xml_3-2.1.0.jar)
[success] Total time: 23 s, completed 10 Sep 2023, 20:37:12
```