### PR TITLE
config for WSActorSystem

### DIFF
--- a/communicator-ws-akka/jvm/src/main/resources/reference.conf
+++ b/communicator-ws-akka/jvm/src/main/resources/reference.conf
@@ -1,0 +1,6 @@
+loci.communicator.ws.akka {
+  akka.http {
+    server {remote-address-header = on}
+    parsing {tls-session-info-header = on}
+  }
+}

--- a/communicator-ws-akka/jvm/src/main/scala/loci/communicator/ws/akka/WSActorSystem.scala
+++ b/communicator-ws-akka/jvm/src/main/scala/loci/communicator/ws/akka/WSActorSystem.scala
@@ -22,13 +22,8 @@ private object WSActorSystem {
 
   def retrieve(): (ActorSystem, ActorMaterializer) = synchronized {
     if (count == 0) {
-      val config = ConfigFactory.parseString(
-        """
-        akka.http {
-          server { remote-address-header = on }
-          parsing { tls-session-info-header = on }
-        }
-        """)
+      val defaultConfig = ConfigFactory.load()
+      val config = defaultConfig.getConfig("loci.communicator.ws.akka").withFallback(defaultConfig)
 
       actorSystem = ActorSystem("websocket-system", config)
       actorMaterializer = ActorMaterializer()

--- a/communicator-ws-akka/jvm/src/test/resources/application.conf
+++ b/communicator-ws-akka/jvm/src/test/resources/application.conf
@@ -1,0 +1,1 @@
+akka.loglevel = "ERROR"

--- a/communicator-ws-akka/jvm/src/test/scala/loci/registry/AkkaWebSocketRegistrySpec.scala
+++ b/communicator-ws-akka/jvm/src/test/scala/loci/registry/AkkaWebSocketRegistrySpec.scala
@@ -3,8 +3,6 @@ package registry
 
 import communicator.ws.akka._
 
-import java.io.{OutputStream, PrintStream}
-
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
 
@@ -15,22 +13,16 @@ class AkkaWebSocketRegistrySpec extends AnyFlatSpec with Matchers with NoLogging
 
   val port = 45848
 
-  val silentStream = new PrintStream(new OutputStream {
-    def write(b: Int) = { }
-  })
-
   it should "handle binding and lookup correctly" in {
     for (_ <- 1 to 50) {
       val listener = WS(port)
       val connector = WS(s"ws://localhost:$port")
 
-      Console.withOut(silentStream) {
-        RegistryTests.`handle binding and lookup correctly`(
-          listener,
-          connector,
-          setupListener = awaitBinding(listener, 1.minute),
-          cleanup = awaitTermination(1.minute))
-      }
+      RegistryTests.`handle binding and lookup correctly`(
+        listener,
+        connector,
+        setupListener = awaitBinding(listener, 1.minute),
+        cleanup = awaitTermination(1.minute))
     }
   }
 
@@ -39,13 +31,11 @@ class AkkaWebSocketRegistrySpec extends AnyFlatSpec with Matchers with NoLogging
       val listener = WS(port)
       val connector = WS(s"ws://localhost:$port")
 
-      Console.withOut(silentStream) {
-        RegistryTests.`handle subjective binding and lookup correctly`(
-          listener,
-          connector,
-          setupListener = awaitBinding(listener, 1.minute),
-          cleanup = awaitTermination(1.minute))
-      }
+      RegistryTests.`handle subjective binding and lookup correctly`(
+        listener,
+        connector,
+        setupListener = awaitBinding(listener, 1.minute),
+        cleanup = awaitTermination(1.minute))
     }
   }
 }


### PR DESCRIPTION
During the investigation of #5, I was surprised to not see any output where I expected to see some, for example errors of Akka and manually added printlns.

In the first commit I move the hardcoded config to a file that can be overwritten by any library users. Please note the commit message.

In the second commit I remove the suppression of console output. As Akka is very chatty, I add a config to the test resources, so that Akka logs only WARN messages.