### PR TITLE
CI: upgrade from JDK 11 to 17, keep JDK 11 for Scala 2.11, add JDK 21 for Scala 3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - uses: coursier/cache-action@v6
       continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,16 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+        jvm: ['11', '17']
         scala: ['2.11', '2.12', '2.13', '3']
         platform: ['jvm', 'js']
+        exclude:
+          - jvm: '11'
+            scala: '2.12'
+          - jvm: '11'
+            scala: '2.13'
+          - jvm: '11'
+            scala: '3'
 
     runs-on: ${{ matrix.os }}
 
@@ -33,10 +41,10 @@ jobs:
     - uses: coursier/cache-action@v6
       continue-on-error: true
 
-    - name: Set up JDK 11
+    - name: Set up JDK ${{ matrix.jvm }}
       uses: coursier/setup-action@v1
       with:
-        jvm: 11
+        jvm: ${{ matrix.jvm }}
         apps: sbt
 
     - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,14 @@
 name: build
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'checkout reference (sha/branch)'
+        required: false
+        type: string
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       continue-on-error: true
 
     - name: Set up JDK 11
-      uses: coursier/setup-action@v1.3.3
+      uses: coursier/setup-action@v1
       with:
         jvm: 11
         apps: sbt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
         scala: ['2.11', '2.12', '2.13', '3']
-        platform: [jvm, js]
+        platform: ['jvm', 'js']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,15 @@ jobs:
             scala: '2.13'
           - jvm: '11'
             scala: '3'
+        include:
+          - os: 'ubuntu-latest'
+            jvm: '21'
+            scala: '3'
+            platform: 'jvm'
+          - os: 'ubuntu-latest'
+            jvm: '21'
+            scala: '3'
+            platform: 'js'
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         scala: ['2.11', '2.12', '2.13', '3']


### PR DESCRIPTION
Adds JDK 17 & 21 to the CI matrix, keeps JDK 11 only for Scala 2.11.

JDK 17 is needed for Jetty >= 12 (and over time, likely more and more libraries).
The CI is currently not failing any Jetty 12 tests, as these are (still) excluded (a5f6afd3).

To keep the matrix from growing too large, I decided to add JDK 21 only for Scala 3 on Linux (like a canary, to catch if we are remaining compatible with the ongoing JDK development).

Likewise I decided to have JDK 11 only for Scala 2.11. I could see potential to have JDK 11 for more jobs, but don't want to increase the matrix without need.

This PR contains some more changes that may need to be discussed:
- 58a783c7 & cde3c369: just some dependency updates, while I was changing the file anyway. I hope I got the intention / history of setup-action@v1.3.3 right.
- a5f17b70: disables fail-fast, so that all jobs continue even when one job fails. Allows restart of just the failed jobs, in case a test is flaky.